### PR TITLE
entrypoint.sh: better management of sign key

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,12 @@ if [ "$DABUILD_DEBUG" = "true" ]; then
 fi
 
 ## generate signing keys on first run
-if [ ! -r "$HOME/.abuild/abuild.conf" ]; then
-  abuild-keygen -n -i -a
+if [ ! -r "$HOME"/.abuild/dabuilder.rsa ]; then
+  abuild-keygen -i -a <<- EOF
+	"$HOME"/.abuild/dabuilder.rsa
+	EOF
 fi
+
+sudo cp -v "$HOME"/.abuild/dabuilder.rsa.pub /etc/apk/keys/
 
 exec "$(command -v abuild)" "$@"


### PR DESCRIPTION
You need to remove any old sign key(s) and any repository index
file(s) signed with old key(s) before first run of new dabuild
as it will use a new static filename for signing key pair:

```
rm ~/.abuild/*.rsa* # remove any old sign key(s)
find ~/packages/ -name APKINDEX.tar.gz -delete # remove any repository index files signed with old key(s)
```