### PR TITLE
Dockerfile: upgrade the installed packages

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -12,6 +12,7 @@ RUN rm /etc/apk/repositories && \
 RUN apk add --update-cache \
       alpine-conf \
       alpine-sdk \
+    && apk upgrade -a \
     && setup-apkcache /var/cache/apk
 
 RUN adduser -D builder \


### PR DESCRIPTION
This is done before the cache is setup to keep the layer clean.

Resolves #23