### PR TITLE
feat: add support for ccache-enabled abuild

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -12,6 +12,7 @@ RUN rm /etc/apk/repositories && \
 RUN apk add --update-cache \
       alpine-conf \
       alpine-sdk \
+      ccache \
     && apk upgrade -a \
     && setup-apkcache /var/cache/apk
 

--- a/dabuild.in
+++ b/dabuild.in
@@ -60,6 +60,7 @@ fi
 ## setup volumes; use named volumes as cache if desired
 ABUILD_VOLUMES="-v ${HOME}/.abuild:/home/builder/.abuild \
   -v ${PWD%/aports*}/aports:/home/builder/aports \
+  -v ${HOME}/.ccache:/home/builder/.ccache \
   -v ${ABUILD_PACKAGES}:/home/builder/packages"
 
 if [ -f "/etc/abuild.conf" ]; then


### PR DESCRIPTION
This introduces support for ccache, when enabled in `abuild`.

As this depends on ccache support within `abuild`; this feature depends on the alpinelinux/abuild#95 patch.

Signed-off-by: Joseph Benden <joe@benden.us>