### PR TITLE
Workaround for ARCH detection

### DIFF
--- a/dabuild.in
+++ b/dabuild.in
@@ -26,9 +26,10 @@ fi
 ## allow setting of arch by env variable
 [ ! "$DABUILD_ARCH" ] && DABUILD_ARCH=$(uname -m)
 case "$DABUILD_ARCH" in
-  x86|x86_64|aarch64|armv6|armv7|armv7l|armv8 ) ;;
+  x86|x86_64|aarch64|armhf|armv7 ) ;;
   * ) die "Unsupported arch \"$DABUILD_ARCH\" detected." \
-          "Expected one of: x86|x86_64|aarch64|armv6|armv7|armv7l|armv8";;
+          "Expected one of: x86|x86_64|aarch64|armhf|armv7" \
+          "You may force it setting DABUILD_ARCH=\"xxx\" in invocation";;
 esac
 
 ## use branch to figure out most appropriate alpine version


### PR DESCRIPTION
Restored alpine docker[ genuinely supported architectures](https://hub.docker.com/r/alpinelinux/docker-abuild/tags) (as other ones are definitely not).
Just give a clue to set wanted DABUILD_ARCH variable at invocation, when uname does not provide adequate info on some platforms like Pi.